### PR TITLE
lib/flashing/devices: Add json files for Jetson Xavier NX devices

### DIFF
--- a/lib/flashing/devices/jetson-xavier-nx-devkit-emmc.json
+++ b/lib/flashing/devices/jetson-xavier-nx-devkit-emmc.json
@@ -1,0 +1,3 @@
+{
+    "type": "jetson"
+}

--- a/lib/flashing/devices/jetson-xavier-nx-devkit.json
+++ b/lib/flashing/devices/jetson-xavier-nx-devkit.json
@@ -1,0 +1,3 @@
+{
+    "type": "jetson"
+}


### PR DESCRIPTION
    The Xavier NX devices are flashed using the jetson-flash node app,
    and they boot from either eMMC or SD-CARD.

Change-type: patch