### PR TITLE
Add jetson-orin-nx-xv3 device type

### DIFF
--- a/lib/features/power/implementations/autokit-relay/README.md
+++ b/lib/features/power/implementations/autokit-relay/README.md
@@ -16,4 +16,8 @@ They used a HID interface and are controllable via:
 - `POWER_RELAY_SERIAL`: the serial of the relay. An example of how to obtain that is here: https://github.com/darrylb123/usbrelay?tab=readme-ov-file#usage 
 - `POWER_RELAY_NUM`: for specifying which channel of the relay is being used for the power control of the DUT in the case of multiple channels being on the relay. Default is `0` which leads to all channels being toggled - actual channel numbers start at `1`
 - `USB_RELAY_CONN`: `NO` or `NC` - for selecting if the normally open or closed configuration is used - default is `NO` and recommended
-- `GPIO_POWER_DET` : (Tx2 specific) - for selecting the PGIO pin to be used for power state detection
+- `GPIO_POWER_DET` : (Tx2 specific) - for selecting the GPIO pin to be used for power state detection
+- `POWER_BTN_RELAY_SERIAL`: (`jetson-orin-nx-xv3` specific) - Select the serial of the secondary relay used to simulate power button presses  
+- `POWER_BTN_RELAY_NUM`: (`jetson-orin-nx-xv3` specific) - Select the channel of the secondary relay used to simulate power button presses 
+- `POWER_BTN_RELAY_CONN`:  (`jetson-orin-nx-xv3` specific) - Select the NO/NC configuration of the secondary relay used to simulate power button presses 
+

--- a/lib/features/power/implementations/autokit-relay/device-overrides/jetson-orin-nx-xv3.ts
+++ b/lib/features/power/implementations/autokit-relay/device-overrides/jetson-orin-nx-xv3.ts
@@ -1,0 +1,46 @@
+import { delay } from 'bluebird';
+import { AutokitRelay } from "..";
+
+// Device specific override for jetson-orin-nx-xv3 power on / off sequencing
+// This implmentation assumes that there are 2 relays or relay channels
+// The primary relay, inherited from the parent class is connected to the mains (super.on() ... etc)
+// The secondary relay, initialised in the child class here is connected to the power button
+export class JetsonOrinNxXv3 extends AutokitRelay {
+    // Instantiate a second relay object to act as the power button relay
+    public pwrBtnRelay: AutokitRelay;
+
+    constructor(){
+        super();
+        this.pwrBtnRelay = new AutokitRelay(
+            (process.env.POWER_BTN_RELAY_SERIAL || 'HURTM'), 
+            Number(process.env.POWER_BTN_RELAY_NUM || '0'),
+            (process.env.POWER_BTN_RELAY_CONN === 'NC') ? false: true,
+        )
+    }
+
+    async setup(): Promise<void> {
+        super.setup();
+        console.log(`Power button Relay ID: ${this.pwrBtnRelay.relayId} is on HID path: ${this.pwrBtnRelay.powerRelay.devicePath}, channel: ${this.pwrBtnRelay.relayNum}`)
+    }
+
+    // Power on the DUT
+    async on(): Promise<void> {
+        // Trigger power on via a short button press - by toggling on, waiting, then toggling off
+        console.log(`Triggering jetson-orin-nx-xv3 power on sequence...`);
+        await delay(1000);
+        await super.on(); // Toggles on mains power - ensures that it is on
+        await delay(1000); // Add a second of waiting to account for delays with the USB commands
+        await this.pwrBtnRelay.on(); // toggles the power button relay to high to simulate the button press
+        await delay(3000); // wait to simulate the period the button is held down
+        await this.pwrBtnRelay.off() // toggles the power button relay to high to simulate letting go of the button
+        await delay(1000); // Add another second of waiting account for delays with the USB commands
+        console.log(`Triggered power on sequence on jetson-orin-nx-xv3!`); 
+    }
+
+    // Power off the DUT
+    async off(): Promise<void> {
+        // Always power off via mains - to ensure the device is really off
+        console.log(`Powering off DUT by switching off mains...`)
+        await super.off()
+    }
+}

--- a/lib/features/power/implementations/autokit-relay/device-overrides/jetson-tx2.ts
+++ b/lib/features/power/implementations/autokit-relay/device-overrides/jetson-tx2.ts
@@ -1,5 +1,5 @@
 import { delay } from 'bluebird';
-import { AutokitRelay } from "./";
+import { AutokitRelay } from "..";
 import { exec } from 'mz/child_process';
 
 // Device specific override for Tx2 power on / off sequencing

--- a/lib/features/power/implementations/autokit-relay/index.ts
+++ b/lib/features/power/implementations/autokit-relay/index.ts
@@ -7,9 +7,13 @@ export class AutokitRelay implements Power {
     public powerRelay: any
     public conn: boolean
     public relayNum: number
-    constructor(){
-        this.relayId = process.env.POWER_RELAY_SERIAL || 'HURTM'
-        this.relayNum = Number(process.env.POWER_RELAY_NUM || '0')
+    constructor(
+        relayId = (process.env.POWER_RELAY_SERIAL || 'HURTM'),
+        relayNum = Number(process.env.POWER_RELAY_NUM || '0'),
+        conn = (process.env.USB_RELAY_CONN === 'NC') ? false: true, // if the user specifies they have set up the connection to be NC
+    ){
+        this.relayId = relayId
+        this.relayNum = relayNum
         let relays = USBRelay.Relays 
         // iterate through the array, and find the relay that is associated with power
         // if there is only one relay, then it doesn't matter
@@ -22,7 +26,7 @@ export class AutokitRelay implements Power {
                 }
             }
         }
-        this.conn = (process.env.USB_RELAY_CONN === 'NC') ? false: true // if the user specifies they have set up the connection to be NC
+        this.conn = conn 
     }
 
     async setup(): Promise<void> {

--- a/lib/features/power/index.ts
+++ b/lib/features/power/index.ts
@@ -1,13 +1,15 @@
 import { AutokitRelay } from "./implementations/autokit-relay";
 import { DummyPower } from "./implementations/dummy-power";
 import { Crelay } from "./implementations/crelay";
-import { JetsonTx2Power } from "./implementations/autokit-relay/jetson-tx2";
+import { JetsonTx2Power } from "./implementations/autokit-relay/device-overrides/jetson-tx2";
+import { JetsonOrinNxXv3 } from "./implementations/autokit-relay/device-overrides/jetson-orin-nx-xv3";
 
 const powerImplementations: {[key: string]: Type<Power> } = {
 	autokitRelay: AutokitRelay,
 	dummyPower: DummyPower,
 	crelay: Crelay,
-	jetsonTx2: JetsonTx2Power
+	jetsonTx2: JetsonTx2Power,
+	jetsonOrinNxXv3: JetsonOrinNxXv3,
 };
 
 export { powerImplementations }

--- a/lib/flashing/devices/jetson-orin-nx-xv3.json
+++ b/lib/flashing/devices/jetson-orin-nx-xv3.json
@@ -1,0 +1,5 @@
+{
+    "type": "jetson",
+    "nvme": true,
+    "machine": "jetson-orin-nx-antmicro-job"
+}

--- a/lib/flashing/index.ts
+++ b/lib/flashing/index.ts
@@ -584,7 +584,8 @@ async function flash(filename: string, deviceType: string, autoKit: Autokit, por
             break;
         }
         case 'jetson': {
-            await flashJetson(filename, autoKit, deviceType, flashProcedure.nvme);
+            let flashMachine = flashProcedure.machine || deviceType
+            await flashJetson(filename, autoKit, flashMachine, flashProcedure.nvme);
             break;
         }
         case 'iot-gate': {

--- a/lib/flashing/powerDetection/ethernet.ts
+++ b/lib/flashing/powerDetection/ethernet.ts
@@ -32,7 +32,7 @@ export async function waitForPowerOffEthernet(autoKit:Autokit):Promise<void>{
     }
 
     const POLL_INTERVAL = 1000; // 1 second
-    const POLL_TRIES = 20; // 20 tries
+    const POLL_TRIES = Number(process.env.POWER_OFF_POLL_TRIES) || 20 // 20 tries by default
     let attempt = 0;
     await delay(1000 * 60);
     while (dutOn) {


### PR DESCRIPTION
This board needed a device specific power mechanism override, and a way to use a different machine name than its DT slug for the jetson flash scripts

Change-type: patch