### PR TITLE
Add emmc flasher type and generic container run

### DIFF
--- a/lib/flashing/devices/generic-emmc-container-boot-switch.json
+++ b/lib/flashing/devices/generic-emmc-container-boot-switch.json
@@ -1,0 +1,5 @@
+{
+    "type": "emmc",
+    "container": true,
+    "jumper": true
+}


### PR DESCRIPTION
This is to enable devices types where an "external" container is run to prepare the device before flashing

Change-type: patch