### PR TITLE
Add retry to serial port opening

### DIFF
--- a/lib/features/serial/implementations/ftdi/index.ts
+++ b/lib/features/serial/implementations/ftdi/index.ts
@@ -18,22 +18,22 @@ export class Ftdi implements Serial {
     }
 
     async open(){
-        if(this.serial.isOpen){
-            console.log(`Serial already open!`);
-            return this.serial;
-        } else {
-            try{
-                console.log(`Opening Serial port ${this.DEV_SERIAL} with baud rate: ${this.BAUD_RATE}`)
-                this.serial.open(() => {
-                    console.log('DUT serial is opened');
-                    this.serial?.flush();
-                })
-                return this.serial;
-            } catch(e){
-                console.log(e)
+        return new Promise((resolve, reject) => {
+            if (this.serial.isOpen) {
+                console.log(`Serial already open!`)
+                return resolve(this.serial);
             }
-            
-        }
+
+            this.serial.open((err: Error | null) => {
+                console.log(`Opening Serial port ${this.DEV_SERIAL} with baud rate: ${this.BAUD_RATE}`)
+                if (err) {
+                    return reject(err);
+                }
+                console.log('DUT serial is opened');
+                this.serial?.flush();
+                resolve(this.serial)
+            });
+        });
     }
 
     async write(data: string): Promise<string | void>  {

--- a/lib/flashing/powerDetection/serial.ts
+++ b/lib/flashing/powerDetection/serial.ts
@@ -1,6 +1,6 @@
 import { Autokit } from '../../';
 import { ReadlineParser } from '@serialport/parser-readline';
-import { Readable } from 'serialport';
+import * as retry from 'bluebird-retry';
 
 const powerOffMessage = process.env.POWER_OFF_MESSAGE || 'reboot: Power down'
 const timeout = Number(process.env.POWER_OFF_TIMEOUT) || 1000*60*5;
@@ -9,8 +9,14 @@ const timeout = Number(process.env.POWER_OFF_TIMEOUT) || 1000*60*5;
  * Checks whether the DUT has powered down by checking for a serial message
  **/
 export async function waitForPowerOffSerial(autoKit:Autokit):Promise<void> {
-    const serialport = await autoKit.serial.open();
-
+    let serialport: any;
+    await retry(async () => {
+        serialport = await autoKit.serial.open();
+    },
+    {
+        interval: 500,
+        max_tries: 10       
+    })
     if(serialport !== undefined){
         return new Promise<void>((resolve, reject) => {
 


### PR DESCRIPTION
When using serial to detect provisioning is completed, there may be a delay before the serial port enumerates, in the case of some devices. This retry stops an error if this happens

Change-type: patch